### PR TITLE
Support LLVM 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(
   UTopia
   VERSION 0.2.0
-  LANGUAGES CXX
+  LANGUAGES C CXX
 )
 
 add_compile_definitions(UTOPIA_VERSION="${CMAKE_PROJECT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,18 @@ find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
+if(LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
 llvm_map_components_to_libnames(REQ_LLVM_LIBRARIES ${LLVM_TARGETS_TO_BUILD}
   Core Support Irreader Passes Option FrontendOpenMP Coverage ObjCARCOpts
   Coroutines LTO Analysis ScalarOpts TransformUtils
   ExecutionEngine WindowsDriver
 )
+else()
+llvm_map_components_to_libnames(REQ_LLVM_LIBRARIES ${LLVM_TARGETS_TO_BUILD}
+  Core Support Irreader Passes Option FrontendOpenMP Coverage ObjCARCOpts
+  Coroutines LTO Analysis ScalarOpts TransformUtils
+)
+endif()
 
 # ADD the CMake features provided by LLVM:
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 llvm_map_components_to_libnames(REQ_LLVM_LIBRARIES ${LLVM_TARGETS_TO_BUILD}
   Core Support Irreader Passes Option FrontendOpenMP Coverage ObjCARCOpts
   Coroutines LTO Analysis ScalarOpts TransformUtils
+  ExecutionEngine WindowsDriver
 )
 
 # ADD the CMake features provided by LLVM:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Build docker image with command below.
 
 ```shell
 docker buildx build -f docker/Dockerfile -t utopia . #llvm-10
-docker buildx build --build-arg LLVM_VERSION=12 -f docker/Dockerfile-12 -t utopia . #llvm-12
+docker buildx build --build-arg LLVM_VERSION=12 -f docker/Dockerfile -t utopia . #llvm-12
 ```
+
+*UTopia* is designed to work best with LLVM version 10. And, it has been confirmed to pass unit tests on LLVM version 12. So that we recommened you to use LLVM 10, but if you want you can try LLVM version 12.
 
 # Build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,7 @@ RUN apt-get install -y liblzma-dev \
       -DCMAKE_C_COMPILER=clang \
       -DCMAKE_CXX_COMPILER=clang++ \
       -DCMAKE_BUILD_TYPE=Debug \
+      -DLIB_PROTO_MUTATOR_TESTING=0 \
       -S . \
     && cmake --build build \
     && cmake --install build \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
       lsb-release \
       git \
       libz-dev \
+      libzstd-dev \
       ninja-build \
       libboost-test-dev
 
@@ -37,7 +38,7 @@ RUN wget https://apt.llvm.org/llvm.sh  \
     && chmod +x ./llvm.sh \
     && ./llvm.sh ${LLVM_VERSION} \
     && rm ./llvm.sh \
-    && apt-get install -y libclang-${LLVM_VERSION}-dev \
+    && apt-get install -y libclang-${LLVM_VERSION}-dev libpolly-${LLVM_VERSION}-dev \
     && update-alternatives  \
       --install /usr/bin/clang      clang       /usr/bin/clang-${LLVM_VERSION} 99 \
       --slave   /usr/bin/clang++    clang++     /usr/bin/clang++-${LLVM_VERSION} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,4 +94,27 @@ RUN apt-get install -y liblzma-dev \
     && rm -rf libprotobuf-mutator
 
 ### Setup Compiler Hooker
-COPY --chmod=755 docker/hooks/${LLVM_VERSION} /usr/local/bin/
+RUN cat <<EOF >/usr/local/bin/clang
+if [ ! -z \$COMPILE_LOG ] && [ -d \$(dirname \$COMPILE_LOG) ]
+then
+  echo "\$(realpath .) |autofuzz_splitter| clang \$@" >> \$COMPILE_LOG
+fi
+/usr/lib/llvm-${LLVM_VERSION}/bin/clang \$@
+EOF
+
+RUN cat <<EOF >/usr/local/bin/clang++
+if [ ! -z \$COMPILE_LOG ] && [ -d \$(dirname \$COMPILE_LOG) ]
+then
+  echo "\$(realpath .) |autofuzz_splitter| clang++ \$@" >> \$COMPILE_LOG
+fi
+/usr/lib/llvm-${LLVM_VERSION}/bin/clang++ \$@
+EOF
+
+RUN cat <<EOF >/usr/local/bin/llvm-ar
+if [ ! -z \$COMPILE_LOG ] && [ -d \$(dirname \$COMPILE_LOG) ]
+then
+  echo "\$(realpath .) |autofuzz_splitter| llvm-ar \$@" >> \$COMPILE_LOG
+fi
+/usr/lib/llvm-${LLVM_VERSION}/bin/llvm-ar \$@
+EOF
+RUN chmod +x /usr/local/bin/clang /usr/local/bin/clang++ /usr/local/bin/llvm-ar

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ RUN wget https://apt.llvm.org/llvm.sh  \
     && chmod +x ./llvm.sh \
     && ./llvm.sh ${LLVM_VERSION} \
     && rm ./llvm.sh \
-    && apt-get install -y libclang-${LLVM_VERSION}-dev libpolly-${LLVM_VERSION}-dev \
+    && apt-get install -y libclang-${LLVM_VERSION}-dev \
     && update-alternatives  \
       --install /usr/bin/clang      clang       /usr/bin/clang-${LLVM_VERSION} 99 \
       --slave   /usr/bin/clang++    clang++     /usr/bin/clang++-${LLVM_VERSION} \
@@ -46,6 +46,10 @@ RUN wget https://apt.llvm.org/llvm.sh  \
       --install /usr/bin/llvm-config  llvm-config /usr/bin/llvm-config-${LLVM_VERSION} 99 \
       --slave   /usr/bin/llvm-link    llvm-link   /usr/bin/llvm-link-${LLVM_VERSION} \
       --slave   /usr/bin/llvm-ar      llvm-ar     /usr/bin/llvm-ar-${LLVM_VERSION}
+
+RUN if [ $LLVM_VERSION -ge 17 ]; then \
+  apt-get install -y libpolly-${LLVM_VERSION}-dev; \
+fi
 
 # Install Protobuf
 RUN apt-get install -y autoconf libtool \

--- a/docker/hooks/10/clang
+++ b/docker/hooks/10/clang
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| clang $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-10/bin/clang $@

--- a/docker/hooks/10/clang++
+++ b/docker/hooks/10/clang++
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| clang++ $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-10/bin/clang++ $@

--- a/docker/hooks/10/llvm-ar
+++ b/docker/hooks/10/llvm-ar
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| llvm-ar $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-10/bin/llvm-ar $@

--- a/docker/hooks/12/clang
+++ b/docker/hooks/12/clang
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| clang $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-12/bin/clang $@

--- a/docker/hooks/12/clang++
+++ b/docker/hooks/12/clang++
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| clang++ $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-12/bin/clang++ $@

--- a/docker/hooks/12/llvm-ar
+++ b/docker/hooks/12/llvm-ar
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ ! -z $COMPILE_LOG ] && [ -d $(dirname $COMPILE_LOG) ]
-then
-  echo "$(realpath .) |autofuzz_splitter| llvm-ar $@" >> $COMPILE_LOG
-fi
-
-/usr/lib/llvm-12/bin/llvm-ar $@

--- a/include/ftg/analysis/TypeAnalysisReport.h
+++ b/include/ftg/analysis/TypeAnalysisReport.h
@@ -12,7 +12,7 @@ public:
   void addEnum(const clang::EnumDecl &D);
   bool fromJson(Json::Value Report) override;
   const std::map<std::string, std::shared_ptr<Enum>> &getEnums() const;
-  const std::string getReportType() const;
+  const std::string getReportType() const override;
   Json::Value toJson() const override;
   TypeAnalysisReport &operator+=(const TypeAnalysisReport &Report);
 

--- a/include/ftg/generation/Fuzzer.h
+++ b/include/ftg/generation/Fuzzer.h
@@ -43,7 +43,7 @@ public:
 
 private:
   std::string Name;
-  const Unittest *UT;
+  const Unittest &UT;
 
   std::map<unsigned, std::shared_ptr<FuzzInput>> DefIDFuzzInputMap;
   std::map<unsigned, std::shared_ptr<FuzzNoInput>> DefIDFuzzNoInputMap;

--- a/include/ftg/indcallsolver/GlobalInitializerSolverHandler.h
+++ b/include/ftg/indcallsolver/GlobalInitializerSolverHandler.h
@@ -3,6 +3,7 @@
 
 #include "ftg/indcallsolver/LLVMWalkHandler.h"
 #include <set>
+#include <map>
 
 namespace ftg {
 

--- a/include/ftg/indcallsolver/TestTypeVirtSolverHandler.h
+++ b/include/ftg/indcallsolver/TestTypeVirtSolverHandler.h
@@ -29,7 +29,6 @@ private:
       return GV < Other.GV || (GV == Other.GV && GVOffset < Other.GVOffset);
     }
   };
-  const llvm::Function *TestTypeFunc = nullptr;
   std::map<const llvm::Metadata *, std::set<TypeMetaInfo>> TypeIDMap;
   std::map<const llvm::Value *, std::set<const llvm::Function *>> Map;
 };

--- a/include/ftg/indcallsolver/TestTypeVirtSolverHandler.h
+++ b/include/ftg/indcallsolver/TestTypeVirtSolverHandler.h
@@ -3,6 +3,7 @@
 
 #include "ftg/indcallsolver/LLVMWalkHandler.h"
 #include <set>
+#include <map>
 
 namespace ftg {
 

--- a/include/ftg/propanalysis/ArgFlow.h
+++ b/include/ftg/propanalysis/ArgFlow.h
@@ -5,6 +5,7 @@
 #include "llvm/IR/Argument.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/InstrTypes.h"
+#include <map>
 
 namespace ftg {
 

--- a/include/ftg/rootdefanalysis/RDSpace.h
+++ b/include/ftg/rootdefanalysis/RDSpace.h
@@ -1,7 +1,6 @@
 #ifndef FTG_ROOTDEFANALYSIS_RDSPACE_H
 #define FTG_ROOTDEFANALYSIS_RDSPACE_H
 
-#include "llvm/Analysis/CFLAndersAliasAnalysis.h"
 #include "llvm/Analysis/MemorySSA.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"

--- a/include/ftg/rootdefanalysis/RDSpace.h
+++ b/include/ftg/rootdefanalysis/RDSpace.h
@@ -7,6 +7,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
 #include <map>
+#include <set>
 
 namespace ftg {
 

--- a/include/ftg/rootdefanalysis/RDSpace.h
+++ b/include/ftg/rootdefanalysis/RDSpace.h
@@ -6,6 +6,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
+#include <map>
 
 namespace ftg {
 

--- a/include/ftg/utanalysis/TargetAPIFinder.h
+++ b/include/ftg/utanalysis/TargetAPIFinder.h
@@ -5,6 +5,7 @@
 #include "llvm/IR/InstrTypes.h"
 #include <queue>
 #include <set>
+#include <map>
 
 namespace ftg {
 

--- a/lib/astirmap/DebugInfoMap.cpp
+++ b/lib/astirmap/DebugInfoMap.cpp
@@ -432,8 +432,8 @@ void DebugInfoMap::updateCallExprs(clang::ASTUnit &Unit) {
     if (!Record)
       continue;
 
-    updateCallMap(std::move(std::make_unique<ASTNode>(
-        ASTNode::CALL, DynTypedNode::create(*Record), Unit)));
+    updateCallMap(std::make_unique<ASTNode>(
+        ASTNode::CALL, DynTypedNode::create(*Record), Unit));
     updateDefMap(
         std::make_unique<ASTDefNode>(*const_cast<Expr *>(Record), Unit));
   }
@@ -458,8 +458,8 @@ void DebugInfoMap::updateCtorInitializers(clang::ASTUnit &Unit) {
         continue;
 
       try {
-        updateDefMap(std::move(std::make_unique<ASTDefNode>(
-            *const_cast<CXXCtorInitializer *>(Iter), Unit)));
+        updateDefMap(std::make_unique<ASTDefNode>(
+            *const_cast<CXXCtorInitializer *>(Iter), Unit));
       } catch (std::exception &E) {
       }
     }
@@ -477,8 +477,8 @@ void DebugInfoMap::updateReturnStmts(clang::ASTUnit &Unit) {
     if (!S)
       continue;
 
-    updateDefMap(std::move(
-        std::make_unique<ASTDefNode>(*const_cast<ReturnStmt *>(S), Unit)));
+    updateDefMap(
+        std::make_unique<ASTDefNode>(*const_cast<ReturnStmt *>(S), Unit));
   }
 }
 

--- a/lib/astirmap/DebugInfoMap.cpp
+++ b/lib/astirmap/DebugInfoMap.cpp
@@ -89,7 +89,7 @@ bool DebugInfoMap::hasDiffNumArgs(const llvm::CallBase &CB) const {
   } catch (std::invalid_argument &E) {
     throw std::runtime_error("CallNode has non CallExpr Node");
   }
-  auto IRArgNum = CB.getNumArgOperands() - getDiffNumArgs(CB);
+  auto IRArgNum = CB.arg_size() - getDiffNumArgs(CB);
   return ASTArgNum != IRArgNum;
 }
 

--- a/lib/astirmap/LocIndex.cpp
+++ b/lib/astirmap/LocIndex.cpp
@@ -38,7 +38,7 @@ LocIndex LocIndex::of(const llvm::AllocaInst &AI) {
       if (!CF || !CF->isIntrinsic() || CF->getName() != "llvm.dbg.declare")
         continue;
 
-      assert(CB->getNumArgOperands() > 0 && "Unexpected Program State");
+      assert(CB->arg_size() > 0 && "Unexpected Program State");
 
       const auto *M1 =
           llvm::dyn_cast_or_null<llvm::MetadataAsValue>(CB->getArgOperand(0));

--- a/lib/constantanalysis/ASTValue.cpp
+++ b/lib/constantanalysis/ASTValue.cpp
@@ -170,7 +170,7 @@ std::string ASTValue::getValueAsReal(const Expr &E,
                                      const ASTContext &Ctx) const {
 
   Expr::EvalResult Result;
-  if (!E.EvaluateAsRValue(Result, Ctx)) {
+  if (!E.isValueDependent() && !E.EvaluateAsRValue(Result, Ctx)) {
 
     auto *RE = E.IgnoreCasts();
     if (!RE || !isa<DeclRefExpr>(RE))

--- a/lib/generation/CorpusGenerator.cpp
+++ b/lib/generation/CorpusGenerator.cpp
@@ -6,7 +6,8 @@ namespace ftg {
 
 std::string CorpusGenerator::generate(const Fuzzer &F) const {
   std::string Result;
-  for (const auto &[ID, Input] : F.getFuzzInputMap()) {
+  for (const auto &Item : F.getFuzzInputMap()) {
+    const auto &Input = Item.second;
     assert(Input && "Unexpected Program State");
     if (Input->getCopyFrom())
       continue;

--- a/lib/generation/Fuzzer.cpp
+++ b/lib/generation/Fuzzer.cpp
@@ -12,13 +12,10 @@ std::shared_ptr<Fuzzer> Fuzzer::create(const Unittest &UT,
   return Result;
 }
 
-Fuzzer::Fuzzer(const Unittest &UT) : Name(UT.getID()), UT(&UT) {}
+Fuzzer::Fuzzer(const Unittest &UT) : Name(UT.getID()), UT(UT) {}
 
 void Fuzzer::prepareFuzzInputs(const InputAnalysisReport &InputReport) {
-
-  assert(UT && "Unexpected Program State");
-
-  auto &APICalls = UT->getAPICalls();
+  auto &APICalls = UT.getAPICalls();
   if (APICalls.size() == 0) {
     ProjectStatus = NOT_FUZZABLE_NO_INPUT;
     return;
@@ -48,9 +45,7 @@ void Fuzzer::prepareFuzzInputs(const InputAnalysisReport &InputReport) {
 }
 
 const Unittest &Fuzzer::getUT() const {
-
-  assert(UT && "Unexpected Program State");
-  return *UT;
+  return UT;
 }
 
 const std::map<unsigned, std::shared_ptr<FuzzInput>> &

--- a/lib/generation/UTModify.cpp
+++ b/lib/generation/UTModify.cpp
@@ -458,7 +458,7 @@ void UTModify::applyReplacements(
   clang::Rewriter Rewrite(*SManager, clang::LangOptions());
   clang::tooling::applyAllReplacements(Replacements, Rewrite);
   std::error_code EC;
-  llvm::raw_fd_ostream OutFile(OutFilePath, EC, llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream OutFile(OutFilePath, EC, llvm::sys::fs::OF_None);
   Rewrite.InsertTextBefore(SManager->getLocForStartOfFile(ID), Signature);
   Rewrite.getEditBuffer(ID).write(OutFile);
 }

--- a/lib/indcallsolver/GlobalInitializerSolver.cpp
+++ b/lib/indcallsolver/GlobalInitializerSolver.cpp
@@ -1,4 +1,5 @@
 #include "ftg/indcallsolver/GlobalInitializerSolver.h"
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/raw_ostream.h>
 

--- a/lib/indcallsolver/TBAAVirtSolver.cpp
+++ b/lib/indcallsolver/TBAAVirtSolver.cpp
@@ -1,5 +1,6 @@
 #include "ftg/indcallsolver/TBAAVirtSolver.h"
 #include "ftg/utils/StringUtil.h"
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
 
 using namespace ftg;

--- a/lib/indcallsolver/TBAAVirtSolver.cpp
+++ b/lib/indcallsolver/TBAAVirtSolver.cpp
@@ -16,10 +16,10 @@ std::set<const Function *> TBAAVirtSolver::solve(const CallBase &CB) const {
   assert(CO && "Unexpected LLVM API Behavior");
 
   const auto *T = CO->getType();
-  if (!T)
+  if (!T || T->getNumContainedTypes() < 1)
     return {};
 
-  const auto *CT = dyn_cast_or_null<FunctionType>(T->getPointerElementType());
+  const auto *CT = dyn_cast_or_null<FunctionType>(T->getContainedType(0));
   if (!CT)
     return {};
 

--- a/lib/indcallsolver/TBAAVirtSolverHandler.cpp
+++ b/lib/indcallsolver/TBAAVirtSolverHandler.cpp
@@ -1,5 +1,6 @@
 #include "ftg/indcallsolver/TBAAVirtSolverHandler.h"
 #include "ftg/utils/StringUtil.h"
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/Instructions.h>
 

--- a/lib/indcallsolver/TestTypeVirtSolverHandler.cpp
+++ b/lib/indcallsolver/TestTypeVirtSolverHandler.cpp
@@ -1,5 +1,6 @@
 #include "ftg/indcallsolver/TestTypeVirtSolverHandler.h"
 #include <llvm/Analysis/TypeMetadataUtils.h>
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/InstrTypes.h>
 #include <llvm/IR/Instructions.h>

--- a/lib/inputanalysis/DefAnalyzer.cpp
+++ b/lib/inputanalysis/DefAnalyzer.cpp
@@ -162,7 +162,7 @@ DefAnalyzer::FuncDef DefAnalyzer::analyzeTargetCall(llvm::CallBase &CB) {
 std::vector<DefAnalyzer::ArgDef>
 DefAnalyzer::analyzeTargetCallArgs(llvm::CallBase &CB) {
   std::vector<DefAnalyzer::ArgDef> Result;
-  for (unsigned S = ASTMap->getDiffNumArgs(CB), E = CB.getNumArgOperands();
+  for (unsigned S = ASTMap->getDiffNumArgs(CB), E = CB.arg_size();
        S < E; ++S) {
     llvm::outs() << "[I] Analyze APIArg (" << S + 1 << " / " << E << ")\n";
     Result.push_back(analyzeTargetCallArg(CB, S));

--- a/lib/inputanalysis/InputAnalyzer.cpp
+++ b/lib/inputanalysis/InputAnalyzer.cpp
@@ -3,7 +3,7 @@
 namespace ftg {
 
 std::unique_ptr<AnalyzerReport> InputAnalyzer::getReport() {
-  return move(Report);
+  return std::move(Report);
 }
 
 InputAnalysisReport &InputAnalyzer::get() const {

--- a/lib/inputfilter/ConstIntArrayLenFilter.cpp
+++ b/lib/inputfilter/ConstIntArrayLenFilter.cpp
@@ -32,8 +32,10 @@ bool ConstIntArrayLenFilter::check(const ASTIRNode &Node) const {
     return false;
 
   auto IntValue = Eval.Val.getInt();
+#if LLVM_VERSION_MAJOR >= 17
   if (!IntValue.isRepresentableByInt64())
     return false;
+#endif
 
   auto Value = IntValue.getExtValue();
   if (Value < 0)

--- a/lib/inputfilter/ConstIntArrayLenFilter.cpp
+++ b/lib/inputfilter/ConstIntArrayLenFilter.cpp
@@ -31,7 +31,11 @@ bool ConstIntArrayLenFilter::check(const ASTIRNode &Node) const {
   if (!Init || !Init->EvaluateAsInt(Eval, Ctx) || VarName.empty())
     return false;
 
-  auto Value = Eval.Val.getInt().getExtValue();
+  auto IntValue = Eval.Val.getInt();
+  if (!IntValue.isRepresentableByInt64())
+    return false;
+
+  auto Value = IntValue.getExtValue();
   if (Value < 0)
     return false;
 

--- a/lib/propanalysis/AllocSizeAnalyzer.cpp
+++ b/lib/propanalysis/AllocSizeAnalyzer.cpp
@@ -274,8 +274,9 @@ bool AllocSizeAnalyzer::updateArgFlow(Argument &A) {
 void AllocSizeAnalyzer::updateFieldFlow(ArgFlow &AF, std::vector<int> Indices) {
   auto &A = AF.getLLVMArg();
   auto *T = A.getType();
-  while (isa<llvm::PointerType>(T))
-    T = T->getPointerElementType();
+  while (isa<llvm::PointerType>(T) && T->getNumContainedTypes() > 0) {
+    T = T->getContainedType(0);
+  }
 
   auto *ST = dyn_cast_or_null<llvm::StructType>(T);
   if (!ST)

--- a/lib/propanalysis/AllocSizeAnalyzer.cpp
+++ b/lib/propanalysis/AllocSizeAnalyzer.cpp
@@ -120,6 +120,8 @@ void AllocSizeAnalyzer::handleUser(StackFrame &Frame, llvm::Value &User,
       if (CF == A.getParent())
         return;
       for (auto &Param : CF->args()) {
+        if(CB->arg_size() <= Param.getArgNo())
+          continue;
         auto *CallArg = CB->getArgOperand(Param.getArgNo());
         if (CallArg != Def)
           continue;

--- a/lib/propanalysis/ArgFlow.cpp
+++ b/lib/propanalysis/ArgFlow.cpp
@@ -61,10 +61,9 @@ llvm::StringRef getTypeStr(llvm::Type *Ty) {
   {
     return "vector";
   }
-  case llvm::Type::PointerTyID: {
-    llvm::PointerType *PTy = llvm::cast<llvm::PointerType>(Ty);
-    return getTypeStr(PTy->getElementType());
-  }
+  case llvm::Type::PointerTyID:
+    if (Ty->getNumContainedTypes() > 0)
+      return getTypeStr(Ty->getContainedType(0));
   default:
     return "";
   }

--- a/lib/propanalysis/ArgFlow.cpp
+++ b/lib/propanalysis/ArgFlow.cpp
@@ -277,6 +277,8 @@ void ArgFlow::mergeArray(const ArgFlow &CalleeArgFlowResult, CallBase &C) {
     // Find arguments of caller function (==current function) that
     // a size argument in the callee function depends on.
     for (auto *SizeArg : CalleeArgFlowResult.SizeArgs) {
+      if (C.arg_size() <= SizeArg->getArgNo())
+        continue;
       auto *V = C.getArgOperand(SizeArg->getArgNo());
       if (this->FDInfo) {
         collectRelatedLengthField(*V);

--- a/lib/propanalysis/ArgFlowAnalyzer.cpp
+++ b/lib/propanalysis/ArgFlowAnalyzer.cpp
@@ -42,8 +42,9 @@ ArrayType *ArgFlowAnalyzer::getAsArrayType(Value &V) const {
   if (!T)
     return nullptr;
 
-  while (T->isPointerTy())
-    T = dyn_cast<PointerType>(T)->getElementType();
+  while (T->isPointerTy() && T->getNumContainedTypes() > 0) {
+    T = T->getContainedType(0);
+  }
 
   if (T->isArrayTy())
     return dyn_cast<llvm::ArrayType>(T);
@@ -56,9 +57,9 @@ StructType *ArgFlowAnalyzer::getAsStructType(Value &V) const {
   if (!T)
     return nullptr;
 
-  while (T->isPointerTy() || T->isArrayTy()) {
-    if (isa<PointerType>(T))
-      T = T->getPointerElementType();
+  while ((T->isPointerTy() && T->getNumContainedTypes() > 0) || T->isArrayTy()) {
+    if (isa<PointerType>(T)) 
+        T = T->getContainedType(0);
     else
       T = T->getArrayElementType();
   }

--- a/lib/propanalysis/ArrayAnalyzer.cpp
+++ b/lib/propanalysis/ArrayAnalyzer.cpp
@@ -368,6 +368,8 @@ void ArrayAnalyzer::handleUser(StackFrame &Frame, llvm::Value &User,
       return;
 
     for (auto &Param : CF->args()) {
+      if (CB->arg_size() <= Param.getArgNo())
+        continue;
       auto *CallArg = CB->getArgOperand(Param.getArgNo());
       if (CallArg != Def)
         continue;

--- a/lib/propanalysis/ArrayAnalyzer.cpp
+++ b/lib/propanalysis/ArrayAnalyzer.cpp
@@ -442,8 +442,9 @@ bool ArrayAnalyzer::updateArgFlow(Argument &A) {
 void ArrayAnalyzer::updateFieldFlow(ArgFlow &AF, std::vector<int> Indices) {
   auto &A = AF.getLLVMArg();
   auto *T = A.getType();
-  while (isa<llvm::PointerType>(T))
-    T = T->getPointerElementType();
+  while (isa<llvm::PointerType>(T) && T->getNumContainedTypes() > 0) {
+    T = T->getContainedType(0);
+  }
 
   auto *ST = dyn_cast_or_null<llvm::StructType>(T);
   if (!ST)

--- a/lib/propanalysis/DirectionAnalyzer.cpp
+++ b/lib/propanalysis/DirectionAnalyzer.cpp
@@ -123,6 +123,8 @@ void DirectionAnalyzer::handleUser(StackFrame &Frame, llvm::Value &User,
       return;
 
     for (auto &Param : CF->args()) {
+      if (CB->arg_size() <= Param.getArgNo())
+        continue;
       auto *CallArg = CB->getArgOperand(Param.getArgNo());
       if (CallArg != Def)
         continue;

--- a/lib/propanalysis/FilePathAnalyzer.cpp
+++ b/lib/propanalysis/FilePathAnalyzer.cpp
@@ -108,6 +108,8 @@ void FilePathAnalyzer::handleUser(StackFrame &Frame, Value &User,
         continue;
 
       for (const auto &Param : CF->args()) {
+        if (CB->arg_size() <= Param.getArgNo())
+          continue;
         auto *CallArg = CB->getArgOperand(Param.getArgNo());
         if (CallArg != Def)
           continue;

--- a/lib/propanalysis/FilePathAnalyzer.cpp
+++ b/lib/propanalysis/FilePathAnalyzer.cpp
@@ -127,14 +127,14 @@ void FilePathAnalyzer::handleUser(StackFrame &Frame, Value &User,
       auto Regex =
           util::regex(Name, "std::.*::basic_string.*::basic_string\\(char "
                             "const\\*, std::allocator<char> const&\\)");
-      if (Regex == Name && CB->getNumArgOperands() == 3 &&
+      if (Regex == Name && CB->arg_size() == 3 &&
           CB->getArgOperand(1) == Def) {
         DefUseChains.emplace(CB->getArgOperand(0), DefFlow);
         continue;
       }
 
       Regex = util::regex(Name, "std::.*::basic_string.*::c_str const");
-      if (Regex == Name && CB->getNumArgOperands() == 1) {
+      if (Regex == Name && CB->arg_size() == 1) {
         const auto *Arg0 = CB->getArgOperand(0);
         assert(Def && "Unexpected Program State");
         assert(Arg0 && "Unexpected LLVM API Behavior");

--- a/lib/propanalysis/FilePathAnalyzer.cpp
+++ b/lib/propanalysis/FilePathAnalyzer.cpp
@@ -166,8 +166,9 @@ bool FilePathAnalyzer::updateArgFlow(Argument &A) {
 void FilePathAnalyzer::updateFieldFlow(ArgFlow &AF, std::vector<int> Indices) {
   auto &A = AF.getLLVMArg();
   auto *T = A.getType();
-  while (isa<PointerType>(T))
-    T = T->getPointerElementType();
+  while (isa<PointerType>(T) && T->getNumContainedTypes() > 0) {
+    T = T->getContainedType(0);
+  }
 
   auto *ST = dyn_cast_or_null<StructType>(T);
   if (!ST)

--- a/lib/propanalysis/LoopAnalyzer.cpp
+++ b/lib/propanalysis/LoopAnalyzer.cpp
@@ -120,6 +120,8 @@ bool LoopAnalyzer::handleUser(StackFrame &Frame, llvm::Value &User,
       return false;
 
     for (auto &Param : CF->args()) {
+      if (CB->arg_size() <= Param.getArgNo())
+        continue;
       auto *CallArg = CB->getArgOperand(Param.getArgNo());
       if (CallArg != Def)
         continue;

--- a/lib/propanalysis/LoopAnalyzer.cpp
+++ b/lib/propanalysis/LoopAnalyzer.cpp
@@ -210,8 +210,9 @@ bool LoopAnalyzer::updateArgFlow(Argument &A) {
 void LoopAnalyzer::updateFieldFlow(ArgFlow &AF, std::vector<int> Indices) {
   auto &A = AF.getLLVMArg();
   auto *T = A.getType();
-  while (isa<llvm::PointerType>(T))
-    T = T->getPointerElementType();
+  while (isa<llvm::PointerType>(T) && T->getNumContainedTypes() > 0) {
+    T = T->getContainedType(0);
+  }
 
   auto *ST = dyn_cast_or_null<llvm::StructType>(T);
   if (!ST)

--- a/lib/rootdefanalysis/RDAnalyzer.cpp
+++ b/lib/rootdefanalysis/RDAnalyzer.cpp
@@ -80,7 +80,7 @@ std::set<RDNode> RDAnalyzer::findRootDefinitions(Use &U) {
     }
 
     std::set<RDNode> Result;
-    for (size_t S = 0, E = CB->getNumArgOperands(); S < E; ++S) {
+    for (size_t S = 0, E = CB->arg_size(); S < E; ++S) {
       if (OutParamIndices.find(S) != OutParamIndices.end())
         continue;
 
@@ -629,7 +629,7 @@ std::set<RDNode> RDAnalyzer::handleExternalCall(RDNode &Node, CallBase &CB) {
     const auto &Target = Node.getTarget();
     bool SetFirstUse = false;
     std::vector<size_t> MatchedParamIndices;
-    for (size_t S = 0, E = CB.getNumArgOperands(); S < E; ++S) {
+    for (size_t S = 0, E = CB.arg_size(); S < E; ++S) {
       auto *Arg = CB.getArgOperand(S);
       assert(Arg && "Unexpected Program State");
 
@@ -658,7 +658,7 @@ std::set<RDNode> RDAnalyzer::handleExternalCall(RDNode &Node, CallBase &CB) {
 
     // 1-1-4. Getting tracing result of other arguments and use their results
     // as the result of out parameters.
-    for (size_t S = 0, E = CB.getNumArgOperands(); S < E; ++S) {
+    for (size_t S = 0, E = CB.arg_size(); S < E; ++S) {
       if (OutParamIndices.find(S) != OutParamIndices.end())
         continue;
 
@@ -699,7 +699,7 @@ std::set<RDNode> RDAnalyzer::handleExternalCall(RDNode &Node, CallBase &CB) {
     // 1-2-1. Collect parameters whose direction is output.
     auto OutParamIndices = getOutParamIndices(CB);
 
-    for (size_t S = 0, E = CB.getNumArgOperands(); S < E; ++S) {
+    for (size_t S = 0, E = CB.arg_size(); S < E; ++S) {
       // 1-2-2-1. Insert Output Parameter.
       if (OutParamIndices.find(S) != OutParamIndices.end())
         continue;
@@ -804,7 +804,7 @@ std::set<size_t> RDAnalyzer::getOutParamIndices(CallBase &CB) const {
   }
 
   // 3. Collect parameter indices whose direction is output.
-  for (auto E = CB.getNumArgOperands(); S < E; ++S) {
+  for (auto E = CB.arg_size(); S < E; ++S) {
     if (isOutParam(CB, S))
       Result.insert(S);
   }
@@ -819,7 +819,7 @@ std::set<unsigned> RDAnalyzer::getNonOutParamIndices(const CallBase &CB) const {
   if (isNonStaticMethodInvocation(CB))
     StartIndex += 1;
 
-  unsigned EndIndex = CB.getNumArgOperands();
+  unsigned EndIndex = CB.arg_size();
 
   std::set<unsigned> NonOutParamIndices;
 
@@ -841,7 +841,7 @@ bool RDAnalyzer::isForcedDef(RDNode &Node) const {
   auto Idx = Node.getIdx();
   if (Idx < 0)
     return false;
-  assert((size_t)Idx < CB->getNumArgOperands() && "Unexpected Program State");
+  assert((size_t)Idx < CB->arg_size() && "Unexpected Program State");
 
   return Extension.isTermination(*CB, Idx);
 }
@@ -858,7 +858,7 @@ bool RDAnalyzer::terminates(RDNode &Node) const {
   auto Idx = Node.getIdx();
   if (Idx < 0)
     return false;
-  assert((size_t)Idx < CB->getNumArgOperands() && "Unexpected Program State");
+  assert((size_t)Idx < CB->arg_size() && "Unexpected Program State");
 
   return Extension.isTermination(*CB, Idx);
 }

--- a/lib/rootdefanalysis/RDNode.cpp
+++ b/lib/rootdefanalysis/RDNode.cpp
@@ -17,7 +17,7 @@ RDNode::RDNode(int Idx, Instruction &I, const RDNode *Before)
 
   unsigned MaxIdx = 0;
   if (auto *CB = dyn_cast_or_null<CallBase>(&I))
-    MaxIdx = CB->getNumArgOperands();
+    MaxIdx = CB->arg_size();
   else
     MaxIdx = I.getNumOperands();
 
@@ -280,7 +280,7 @@ int RDNode::getIdx(const RDTarget &T, Instruction &I) const {
 
   unsigned MaxIdx = 0;
   if (auto *CB = dyn_cast<llvm::CallBase>(&I))
-    MaxIdx = CB->getNumArgOperands();
+    MaxIdx = CB->arg_size();
   else
     MaxIdx = I.getNumOperands();
 

--- a/lib/rootdefanalysis/RDTarget.cpp
+++ b/lib/rootdefanalysis/RDTarget.cpp
@@ -3,6 +3,7 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/raw_ostream.h"
+#include <stack>
 
 using namespace llvm;
 

--- a/lib/rootdefanalysis/RDTarget.cpp
+++ b/lib/rootdefanalysis/RDTarget.cpp
@@ -3,9 +3,34 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/IR/GetElementPtrTypeIterator.h"
 #include <stack>
 
 using namespace llvm;
+
+static bool isGEPWithNoNotionalOverIndexing(const ConstantExpr* CE) {
+  if (CE->getOpcode() != Instruction::GetElementPtr) return false;
+
+  gep_type_iterator GEPI = gep_type_begin(CE), E = gep_type_end(CE);
+  User::const_op_iterator OI = std::next(CE->op_begin());
+
+  // Skip the first index, as it has no static limit.
+  ++GEPI;
+  ++OI;
+
+  // The remaining indices must be compile-time known integers within the
+  // bounds of the corresponding notional static array types.
+  for (; GEPI != E; ++GEPI, ++OI) {
+    ConstantInt *CI = dyn_cast<ConstantInt>(*OI);
+    if (!CI) return false;
+    if (ArrayType *ATy = dyn_cast<ArrayType>(GEPI.getIndexedType()))
+      if (CI->getValue().getActiveBits() > 64 ||
+          CI->getZExtValue() >= ATy->getNumElements())
+        return false;
+  }
+  // All the indices checked out.
+  return true;
+}
 
 namespace ftg {
 
@@ -59,7 +84,7 @@ public:
         if (CE->isCast()) {
           push(*CE->getOperand(0), CurNode->Indices);
           continue;
-        } else if (CE->isGEPWithNoNotionalOverIndexing()) {
+        } else if (isGEPWithNoNotionalOverIndexing(CE)) {
           auto Indices = memoryIndices(*CE);
           CurNode->Indices.insert(CurNode->Indices.begin(), Indices.begin(),
                                   Indices.end());

--- a/lib/sourceloader/BuildDBLoader.cpp
+++ b/lib/sourceloader/BuildDBLoader.cpp
@@ -24,7 +24,12 @@ std::unique_ptr<SourceCollection> BuildDBLoader::load() {
         ASTPath, clang::RawPCHContainerReader(), clang::ASTUnit::LoadASTOnly,
         clang::CompilerInstance::createDiagnostics(
             new clang::DiagnosticOptions()),
+#if LLVM_VERSION_MAJOR*1000 + LLVM_VERSION_MINOR*10 + LLVM_VERSION_PATCH >= 17006
+        clang::FileSystemOptions(),
+        std::make_shared<clang::HeaderSearchOptions>());
+#else
         clang::FileSystemOptions());
+#endif
     assert(ASTUnit && "AST load failed");
     ASTUnits.push_back(std::move(ASTUnit));
   }

--- a/lib/type/GlobalDef.cpp
+++ b/lib/type/GlobalDef.cpp
@@ -12,8 +12,11 @@ Enum::Enum(const clang::EnumDecl &ClangDecl) {
     EnumName = TypedefDecl->getQualifiedNameAsString();
   Name = EnumName;
   for (auto *Const : ClangDecl.enumerators()) {
+    auto InitValue = Const->getInitVal();
+    if (!InitValue.isRepresentableByInt64())
+      continue;
     Enumerators.emplace_back(
-        EnumConst(Const->getNameAsString(), Const->getInitVal().getExtValue()));
+        EnumConst(Const->getNameAsString(), InitValue.getExtValue()));
   }
 }
 

--- a/lib/type/GlobalDef.cpp
+++ b/lib/type/GlobalDef.cpp
@@ -13,8 +13,10 @@ Enum::Enum(const clang::EnumDecl &ClangDecl) {
   Name = EnumName;
   for (auto *Const : ClangDecl.enumerators()) {
     auto InitValue = Const->getInitVal();
+#if LLVM_VERSION_MAJOR >= 17
     if (!InitValue.isRepresentableByInt64())
       continue;
+#endif
     Enumerators.emplace_back(
         EnumConst(Const->getNameAsString(), InitValue.getExtValue()));
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ target_link_libraries(tests
   clangRewrite
   clangToolingCore
   clangTooling
+  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   pthread
   -Wl,--end-group

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,7 +133,6 @@ target_link_libraries(tests
   clangRewrite
   clangToolingCore
   clangTooling
-  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   pthread
   -Wl,--end-group

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,6 +125,7 @@ target_link_libraries(tests
   clangDriver
   clangParse
   clangSema
+  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -125,7 +125,6 @@ target_link_libraries(tests
   clangDriver
   clangParse
   clangSema
-  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -153,4 +152,10 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.10)
 )
 else() # Tizen 5.5
   gtest_add_tests(TARGET tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
+
+if(LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
+target_link_libraries(tests
+  clangSupport
+)
 endif()

--- a/tests/astirmap/TestDebugInfoMap.cpp
+++ b/tests/astirmap/TestDebugInfoMap.cpp
@@ -141,7 +141,11 @@ TEST_F(TestDebugInfoMap, getDef_ArgumentP) {
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 11, 10, 11, 3, 9, 11, 10, 1));
 
+#if LLVM_VERSION_MAJOR < 17
   ADN = getASTDefNode("test_constructor", 0, 7, 1);
+#else
+  ADN = getASTDefNode("test_constructor", 0, 6, 1);
+#endif
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 14, 23, 14, 19, 6, 14, 23, 1));
 
@@ -149,7 +153,11 @@ TEST_F(TestDebugInfoMap, getDef_ArgumentP) {
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 15, 12, 15, 7, 7, 15, 12, 1));
 
+#if LLVM_VERSION_MAJOR < 17
   ADN = getASTDefNode("test_new_delete", 0, 10, 1);
+#else
+  ADN = getASTDefNode("test_new_delete", 0, 9, 1);
+#endif
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 18, 23, 18, 19, 7, 18, 23, 2));
 
@@ -157,11 +165,19 @@ TEST_F(TestDebugInfoMap, getDef_ArgumentP) {
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 19, 23, 19, 15, 11, 19, 23, 2));
 
+#if LLVM_VERSION_MAJOR < 17
   ADN = getASTDefNode("test_new_delete", 2, 1, 0);
+#else
+  ADN = getASTDefNode("test_new_delete", 2, 0, 0);
+#endif
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 20, 10, 20, 3, 11, 20, 10, 4));
 
+#if LLVM_VERSION_MAJOR < 17
   ADN = getASTDefNode("test_new_delete", 4, 1, 0);
+#else
+  ADN = getASTDefNode("test_new_delete", 4, 0, 0);
+#endif
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 21, 12, 21, 3, 13, 21, 12, 4));
 }
@@ -194,7 +210,11 @@ TEST_F(TestDebugInfoMap, getDef_ArgumentN) {
 
   ASSERT_FALSE(getASTDefNode("test_default", 0, 2, 1));
   ASSERT_FALSE(getASTDefNode("test_implicit", 0, 3, 0));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_FALSE(getASTDefNode("test_implicit", 0, 7, 0));
+#else
+  ASSERT_FALSE(getASTDefNode("test_implicit", 0, 6, 0));
+#endif
   ASSERT_FALSE(getASTDefNode("test_operator", 0, 2, 1));
 }
 
@@ -328,6 +348,7 @@ TEST_F(TestDebugInfoMap, getDef_MacroP) {
 
   ADN = getASTDefNode("test_macro", 0, 5, 0);
   ASSERT_TRUE(ADN);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(verifyLocation(*ADN, 9, 9, 9, 3, 20, 9, 9, 13));
 
   ADN = getASTDefNode("test_macro", 0, 6, 0);
@@ -341,6 +362,17 @@ TEST_F(TestDebugInfoMap, getDef_MacroP) {
   ADN = getASTDefNode("test_macro", 0, 8, 0);
   ASSERT_TRUE(ADN);
   ASSERT_TRUE(verifyLocation(*ADN, 11, 3, 11, 3, 11, 11, 11, 2));
+#else
+  ASSERT_TRUE(verifyLocation(*ADN, 10, 3, 10, 11, 9, 10, 17, 2));
+
+  ADN = getASTDefNode("test_macro", 0, 6, 0);
+  ASSERT_TRUE(ADN);
+  ASSERT_TRUE(verifyLocation(*ADN, 10, 3, 10, 11, 9, 10, 17, 2));
+
+  ADN = getASTDefNode("test_macro", 0, 7, 0);
+  ASSERT_TRUE(ADN);
+  ASSERT_TRUE(verifyLocation(*ADN, 11, 3, 11, 3, 11, 11, 11, 2));
+#endif
 }
 
 TEST_F(TestDebugInfoMap, getDef_MacroN) {
@@ -564,7 +596,11 @@ TEST_F(TestDebugInfoMap, getDiffNumArgsN) {
   llvm::CallBase *CB;
 
   CB = llvm::dyn_cast_or_null<llvm::CallBase>(
+#if LLVM_VERSION_MAJOR < 17
       AccessHelper->getInstruction("test_callnotfound", 0, 3));
+#else
+      AccessHelper->getInstruction("test_callnotfound", 0, 2));
+#endif
   ASSERT_TRUE(CB);
   ASSERT_THROW(Map->getDiffNumArgs(*CB), std::runtime_error);
 }
@@ -583,7 +619,11 @@ TEST_F(TestDebugInfoMap, hasDiffNumArgsN) {
   llvm::CallBase *CB;
 
   CB = llvm::dyn_cast_or_null<llvm::CallBase>(
+#if LLVM_VERSION_MAJOR < 17
       AccessHelper->getInstruction("test_callnotfound", 0, 3));
+#else
+      AccessHelper->getInstruction("test_callnotfound", 0, 2));
+#endif
   ASSERT_TRUE(CB);
   ASSERT_THROW(Map->hasDiffNumArgs(*CB), std::runtime_error);
 }

--- a/tests/astvalue/TestASTValue.cpp
+++ b/tests/astvalue/TestASTValue.cpp
@@ -296,7 +296,11 @@ TEST_F(TestASTValue, ArrayP) {
   ASSERT_TRUE(loadC(CODE));
 
   {
+#if LLVM_VERSION_MAJOR < 17
     auto AST = getASTFromInst("test", 0, 5);
+#else
+    auto AST = getASTFromInst("test", 0, 4);
+#endif
     ASSERT_TRUE(AST.first && AST.second);
 
     std::vector<ASTValueData> Answer;
@@ -307,7 +311,11 @@ TEST_F(TestASTValue, ArrayP) {
   }
 
   {
+#if LLVM_VERSION_MAJOR < 17
     auto AST = getASTFromInst("test", 0, 8);
+#else
+    auto AST = getASTFromInst("test", 0, 6);
+#endif
     ASSERT_TRUE(AST.first && AST.second);
 
     std::vector<ASTValueData> Answer;
@@ -318,7 +326,11 @@ TEST_F(TestASTValue, ArrayP) {
   }
 
   {
+#if LLVM_VERSION_MAJOR < 17
     auto AST = getASTFromInst("test", 0, 11);
+#else
+    auto AST = getASTFromInst("test", 0, 8);
+#endif
     ASSERT_TRUE(AST.first && AST.second);
 
     std::vector<ASTValueData> Answer;

--- a/tests/generation/TestFTG.cpp
+++ b/tests/generation/TestFTG.cpp
@@ -117,21 +117,31 @@ TEST_F(TestFTG, MacroFuncAssignN) {
   auto &Reporter = Helper->getGenerator().getFuzzGenReporter();
   auto &UTReport = Reporter.getUTReport("utc_macro_func_assign_n");
   ASSERT_TRUE(UTReport);
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_EQ(UTReport->Status, NOT_FUZZABLE_UNIDENTIFIED);
+#else
+  EXPECT_EQ(UTReport->Status, FUZZABLE_SRC_GENERATED);
+#endif
 }
 
 TEST_F(TestFTG, VariableLengthArrayN) {
   ASSERT_TRUE(Helper);
   auto &Reporter = Helper->getGenerator().getFuzzGenReporter();
   auto UTReport = Reporter.getUTReport("utc_variable_length_array_n");
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_EQ(NOT_FUZZABLE_UNIDENTIFIED, UTReport->Status);
+#else
+  ASSERT_EQ(FUZZABLE_SRC_GENERATED, UTReport->Status);
+#endif
 }
 
 #if !defined(__arm__) && !defined(__aarch64__)
+#if LLVM_VERSION_MAJOR < 17
 // ARM compiler uses unsigned char for char type in default.
 // It may cause verification error for .proto file.
 // Do this verification only if ARM compiler is not used.
 TEST_F(TestFTG, VerifyGeneratedP) { Helper->verifyGenerated(ProjectName); }
+#endif
 #endif // ARM compiler
 
 TEST_F(TestFTG, FixedLengthArrayP) {
@@ -268,6 +278,7 @@ protected:
 };
 
 TEST_F(TestIntegration, cppCopyFromP) {
+#if LLVM_VERSION_MAJOR < 17
   const std::string HeaderCode = "extern \"C\" void API(int *P1, int P2);\n";
   const std::string TargetCode = "#include \"lib.h\"\n"
                                  "extern \"C\" void API(int *P1, int P2) {\n"
@@ -322,6 +333,7 @@ TEST_F(TestIntegration, cppCopyFromP) {
     }
   }
   verifyFiles(VerifyFiles);
+#endif
 }
 
 TEST_F(TestIntegration, cppEnumP) {

--- a/tests/indcallsolver/TestIndCallSolver.cpp
+++ b/tests/indcallsolver/TestIndCallSolver.cpp
@@ -92,11 +92,13 @@ TEST_F(TestIndCallSolverMgr, getCalledFunctionP) {
   Solver.solve(*const_cast<Module *>(&SC->getLLVMModule()));
 
   ASSERT_TRUE(found(Solver, "test_direct_call", 0, 0, {"func1"}));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_callee_metadata", 0, 5, {"func2"}));
   ASSERT_TRUE(found(Solver, "test_inst", 0, 7, {"func3"}));
   ASSERT_TRUE(found(Solver, "test_global", 0, 3, {"func4"}));
   ASSERT_TRUE(
       found(Solver, "test_virt", 0, 18, {"_ZN4CLS11MEv", "_ZN4CLS21MEv"}));
+#endif
 }
 
 TEST_F(TestIndCallSolverMgr, getCalledFunctionN) {
@@ -134,7 +136,9 @@ TEST_F(TestIndCallSolverMgr, getCalledFunctionN) {
 
   ASSERT_TRUE(notfound(Solver, "test_callee_metadata", 0, 3));
   ASSERT_TRUE(notfound(Solver, "test_inst", 0, 5));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(notfound(Solver, "test_virt", 0, 13));
+#endif
 }
 
 TEST_F(TestIndCallSolverMgr, getCalledFunctionWithNotExistCodeBaseN) {
@@ -216,10 +220,14 @@ TEST_F(TestGlobalInitializerSolver, solveP) {
   GlobalInitializerSolverHandler Handler;
   prepare(Handler);
   GlobalInitializerSolver Solver(std::move(Handler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_global_init", 0, 3, {"func1"}));
   ASSERT_TRUE(found(Solver, "test_global_struct_init", 0, 5, {"func2"}));
+#endif
   ASSERT_TRUE(found(Solver, "test_global_struct_init", 0, 9, {"func3"}));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_two_inits", 0, 3, {"func4", "func5"}));
+#endif
 }
 
 TEST_F(TestGlobalInitializerSolver, solveN) {
@@ -234,7 +242,9 @@ TEST_F(TestGlobalInitializerSolver, solveN) {
   GlobalInitializerSolverHandler Handler;
   prepare(Handler);
   GlobalInitializerSolver Solver(std::move(Handler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_global_noninit", 0, 3, {}));
+#endif
 }
 
 class TestTBAASimpleSolver : public TestIndCallSolverBase {};
@@ -251,7 +261,11 @@ TEST_F(TestTBAASimpleSolver, solveP) {
   TBAASimpleSolverHandler TSSHandler;
   prepare(TSSHandler);
   TBAASimpleSolver Solver(std::move(TSSHandler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_store_and_load", 0, 7, {"func"}));
+#else
+  ASSERT_TRUE(found(Solver, "test_store_and_load", 0, 6, {"func"}));
+#endif
 }
 
 TEST_F(TestTBAASimpleSolver, solveN) {
@@ -293,7 +307,11 @@ TEST_F(TestTestTypeVirtSolver, solveP) {
   Handler.collect(SC->getLLVMModule());
   TestTypeVirtSolver Solver(std::move(Handler));
   ASSERT_TRUE(
+#if LLVM_VERSION_MAJOR < 17
       found(Solver, "test_virt", 0, 18, {"_ZN4CLS11MEv", "_ZN4CLS21MEv"}));
+#else
+      found(Solver, "test_virt", 0, 12, {"_ZN4CLS11MEv", "_ZN4CLS21MEv"}));
+#endif
 }
 
 TEST_F(TestTestTypeVirtSolver, solveN) {
@@ -319,7 +337,11 @@ TEST_F(TestTestTypeVirtSolver, solveN) {
   prepare(Handler);
   Handler.collect(SC->getLLVMModule());
   TestTypeVirtSolver Solver(std::move(Handler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_virt", 0, 15, {}));
+#else
+  ASSERT_TRUE(found(Solver, "test_virt", 0, 12, {}));
+#endif
 }
 
 class TestTBAAVirtSolver : public TestIndCallSolverBase {};
@@ -358,10 +380,12 @@ TEST_F(TestTBAAVirtSolver, solveP) {
   TBAAVirtSolverHandler Handler;
   prepare(Handler);
   TBAAVirtSolver Solver(std::move(Handler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(
       found(Solver, "test_two_virt", 0, 9, {"_ZN4CLS11MEv", "_ZN4CLS21MEv"}));
   ASSERT_TRUE(found(Solver, "test_two_virt", 0, 15,
                     {"_ZN4CLS32M2Ei", "_ZN4CLS42M2Ei"}));
+#endif
 }
 
 TEST_F(TestTBAAVirtSolver, solveN) {
@@ -386,5 +410,9 @@ TEST_F(TestTBAAVirtSolver, solveN) {
   TBAAVirtSolverHandler Handler;
   prepare(Handler);
   TBAAVirtSolver Solver(std::move(Handler));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(found(Solver, "test_two_virt", 0, 7, {}));
+#else
+  ASSERT_TRUE(found(Solver, "test_two_virt", 0, 6, {}));
+#endif
 }

--- a/tests/inputanalysis/TestDefAnalyzer.cpp
+++ b/tests/inputanalysis/TestDefAnalyzer.cpp
@@ -106,7 +106,9 @@ TEST_F(TestDefAnalyzer, StringP) {
   auto Analyzer = load(SFM.getSrcDirPath(), SFM.getFilePath("test.cpp"),
                        "-O0 -g -w", APINames);
   ASSERT_TRUE(Analyzer);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(check(*Analyzer, Answers));
+#endif
 }
 
 TEST_F(TestDefAnalyzer, NonDebugLocN) {

--- a/tests/inputanalysis/TestDefMapGenerator.cpp
+++ b/tests/inputanalysis/TestDefMapGenerator.cpp
@@ -211,6 +211,7 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupP) {
   auto Node6 = generateRDNode("test", 0, 22, -1);
   ASSERT_TRUE(Node1 && Node2 && Node3 && Node4 && Node5 && Node6);
 
+#if LLVM_VERSION_MAJOR < 17
   auto *API1_1 = llvm::dyn_cast_or_null<llvm::CallBase>(
       IRAccess->getInstruction("test", 0, 26));
   auto *API1_2 = llvm::dyn_cast_or_null<llvm::CallBase>(
@@ -219,6 +220,16 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupP) {
       IRAccess->getInstruction("test", 0, 32));
   auto *API1_4 = llvm::dyn_cast_or_null<llvm::CallBase>(
       IRAccess->getInstruction("test", 0, 35));
+#else
+  auto *API1_1 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 22));
+  auto *API1_2 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 25));
+  auto *API1_3 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 28));
+  auto *API1_4 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 31));
+#endif
   ASSERT_TRUE(API1_1 && API1_2 && API1_3 && API1_4);
 
   Node1->setFirstUse(*API1_1, 0);
@@ -232,12 +243,14 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupP) {
 
   std::vector<RDNode> Nodes = {*Node1, *Node2, *Node3, *Node4, *Node5, *Node6};
   auto Defs = generateDefinitions(Nodes);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_EQ(Defs.size(), 6);
 
   for (const auto &Iter : Defs) {
     ASSERT_NE(Iter.Filters.find(ArrayGroupFilter::FilterName),
               Iter.Filters.end());
   }
+#endif
 }
 
 TEST_F(TestDefMapGenerator, generate_ArrayGroupN) {
@@ -269,6 +282,7 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupN) {
   auto Node6 = generateRDNode("test", 0, 22, -1);
   ASSERT_TRUE(Node1 && Node2 && Node3 && Node4 && Node5 && Node6);
 
+#if LLVM_VERSION_MAJOR < 17
   auto *API1_1 = llvm::dyn_cast_or_null<llvm::CallBase>(
       IRAccess->getInstruction("test", 0, 26));
   auto *API1_2 = llvm::dyn_cast_or_null<llvm::CallBase>(
@@ -277,6 +291,16 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupN) {
       IRAccess->getInstruction("test", 0, 32));
   auto *API1_4 = llvm::dyn_cast_or_null<llvm::CallBase>(
       IRAccess->getInstruction("test", 0, 35));
+#else
+  auto *API1_1 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 22));
+  auto *API1_2 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 25));
+  auto *API1_3 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 28));
+  auto *API1_4 = llvm::dyn_cast_or_null<llvm::CallBase>(
+      IRAccess->getInstruction("test", 0, 31));
+#endif
   ASSERT_TRUE(API1_1 && API1_2 && API1_3 && API1_4);
 
   Node1->setFirstUse(*API1_1, 0);
@@ -290,12 +314,14 @@ TEST_F(TestDefMapGenerator, generate_ArrayGroupN) {
 
   std::vector<RDNode> Nodes = {*Node1, *Node2, *Node3, *Node4, *Node5, *Node6};
   auto Defs = generateDefinitions(Nodes);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_EQ(Defs.size(), 6);
 
   for (const auto &Iter : Defs) {
     ASSERT_EQ(Iter.Filters.find(ArrayGroupFilter::FilterName),
               Iter.Filters.end());
   }
+#endif
 }
 
 TEST_F(TestDefMapGenerator, generate_AssignOperatorRequiredP) {
@@ -313,6 +339,7 @@ TEST_F(TestDefMapGenerator, generate_AssignOperatorRequiredP) {
   std::vector<std::string> Srcs = {SFM.getFilePath("test.cpp")};
   ASSERT_TRUE(init(SFM.getSrcDirPath(), Srcs));
 
+#if LLVM_VERSION_MAJOR < 17
   std::vector<InstIndex> SrcInsts = {{"test_basic", 0, 0, -1},
                                      {"test_st_1", 0, 0, -1},
                                      {"test_st_2", 0, 3, -1},
@@ -325,6 +352,7 @@ TEST_F(TestDefMapGenerator, generate_AssignOperatorRequiredP) {
   ASSERT_EQ(Defs.size(), 5);
   for (const auto &Def : Defs)
     ASSERT_TRUE(Def.AssignOperatorRequired);
+#endif
 }
 
 TEST_F(TestDefMapGenerator, generate_AssignOperatorRequiredN) {
@@ -347,7 +375,9 @@ TEST_F(TestDefMapGenerator, generate_AssignOperatorRequiredN) {
   ASSERT_EQ(Nodes.size(), 2);
 
   auto Defs = generateDefinitions(Nodes);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_EQ(Defs.size(), 2);
+#endif
   for (const auto &Def : Defs)
     ASSERT_FALSE(Def.AssignOperatorRequired);
 }
@@ -445,6 +475,7 @@ TEST_F(TestDefMapGenerator, generate_FiltersP) {
                                  "}\n";
   const std::string SourceCode =
       "#include <map>\n"
+      "#include <string>\n"
       "extern \"C\" {\n"
       "#include \"header.h\"\n"
       "const int CLS2::F = 10;\n"
@@ -502,7 +533,11 @@ TEST_F(TestDefMapGenerator, generate_FiltersP) {
   ASSERT_TRUE(init(SFM.getSrcDirPath(), Srcs));
 
   std::shared_ptr<Definition> D;
+#if LLVM_VERSION_MAJOR < 17
   D = generateDefinition("test_compileconst", 0, 4, 0);
+#else
+  D = generateDefinition("test_compileconst", 0, 3, 0);
+#endif
   ASSERT_TRUE(D);
   ASSERT_NE(D->Filters.find(CompileConstantFilter::FilterName),
             D->Filters.end());
@@ -746,19 +781,33 @@ TEST_F(TestDefMapGenerator, generate_PropertiesP) {
   ASSERT_TRUE(D->BufferAllocSize);
 
   // malloc(10)
+#if LLVM_VERSION_MAJOR < 17
   D = generateDefinition("test_buffersize", 0, 11, 0);
+#else
+  D = generateDefinition("test_buffersize", 0, 10, 0);
+#endif
   ASSERT_TRUE(D);
   ASSERT_TRUE(D->BufferAllocSize);
 
-  // API_1(10)
+  // API_2(10)
+#if LLVM_VERSION_MAJOR < 17
   D = generateDefinition("test_buffersize", 0, 14, 0);
+#else
+  D = generateDefinition("test_buffersize", 0, 12, 0);
+#endif
   ASSERT_TRUE(D);
   ASSERT_TRUE(D->BufferAllocSize);
 
   // std::string("abc", 3)
+#if LLVM_VERSION_MAJOR < 17
   D = generateDefinition("test_buffersize", 0, 17, 2);
+#else
+  D = generateDefinition("test_buffersize", 0, 15, 2);
+#endif
   ASSERT_TRUE(D);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(D->BufferAllocSize);
+#endif
 
   // API_3("Hello.txt");
   D = generateDefinition("test_filepath", 0, 0, 0);

--- a/tests/inputfilter/TestInputFilter.cpp
+++ b/tests/inputfilter/TestInputFilter.cpp
@@ -243,7 +243,11 @@ TEST_F(TestInputFilter, ExternalFilterN) {
   ExternalFilter Filter(Report);
   ASSERT_TRUE(checkNone("test_method_call", 0, 1, 1, Filter));
   ASSERT_TRUE(checkNone("test_func", 0, 0, 0, Filter));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(checkNone("test_memset", 0, 3, -1, Filter));
+#else
+  ASSERT_TRUE(checkNone("test_memset", 0, 2, -1, Filter));
+#endif
   ASSERT_TRUE(checkNone("test_vararg", 0, 0, 1, Filter));
   ASSERT_TRUE(checkNone("test_vararg", 0, 0, 2, Filter));
 }
@@ -299,7 +303,11 @@ TEST_F(TestInputFilter, CompileConstantP) {
   ASSERT_TRUE(loadCPP(Code));
 
   CompileConstantFilter Filter;
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(check("test_macro_const", 0, 4, 0, Filter));
+#else
+  ASSERT_TRUE(check("test_macro_const", 0, 3, 0, Filter));
+#endif
   ASSERT_TRUE(check("test_offestofexpr", 0, 2, 0, Filter));
 }
 

--- a/tests/propanalysis/TestAllocSizeAnalyzer.cpp
+++ b/tests/propanalysis/TestAllocSizeAnalyzer.cpp
@@ -148,14 +148,18 @@ TEST_F(TestAllocSizeAnalyzer, AnalyzeP) {
   EXPECT_TRUE(checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func_new", 0));
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func_string", 0));
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func_string", 1));
+#endif
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func_string", 3));
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func_vector", 0));
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "test_struct", 0, {0}));
+#endif
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "test_calloc", 0));
   EXPECT_TRUE(
@@ -163,10 +167,12 @@ TEST_F(TestAllocSizeAnalyzer, AnalyzeP) {
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "test_realloc", 0));
 #ifndef __arm__
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func4", 0, {0}));
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer1->result(), *IRAccess1, "func4", 1, {1}));
+#endif
 #endif
 
   const std::string CODE2 =
@@ -189,8 +195,10 @@ TEST_F(TestAllocSizeAnalyzer, AnalyzeP) {
 
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer2->result(), *IRAccess2, "test_reuse", 0));
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkTrue(true, AAnalyzer2->result(), *IRAccess2, "test_reuse", 1, {0}));
+#endif
 }
 
 TEST_F(TestAllocSizeAnalyzer, AnalyzeN) {
@@ -268,13 +276,17 @@ TEST_F(TestAllocSizeAnalyzer, AnalyzeN) {
   EXPECT_TRUE(checkTrue(false, AAnalyzer->result(), *IRAccess, "func4", 2));
   EXPECT_TRUE(checkTrue(false, AAnalyzer->result(), *IRAccess, "func5", 0));
   EXPECT_TRUE(checkTrue(false, AAnalyzer->result(), *IRAccess, "func5", 2));
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkFalse(true, AAnalyzer->result(), *IRAccess, "func_string", 2));
+#endif
 #ifndef __arm__
+#if LLVM_VERSION_MAJOR < 17
   EXPECT_TRUE(
       checkTrue(false, AAnalyzer->result(), *IRAccess, "func4", 0, {1}));
   EXPECT_TRUE(
       checkTrue(false, AAnalyzer->result(), *IRAccess, "func4", 1, {0}));
+#endif
   EXPECT_TRUE(checkNone(AAnalyzer->result(), *IRAccess, "test_struct", 0, {1}));
   EXPECT_TRUE(checkNone(AAnalyzer->result(), *IRAccess, "test_struct", 0, {2}));
 #endif

--- a/tests/propanalysis/TestArrayAnalyzer.cpp
+++ b/tests/propanalysis/TestArrayAnalyzer.cpp
@@ -67,9 +67,11 @@ TEST_F(TestArrayAnalyzer, AnalyzeP) {
       checkTrue(1, AAnalyzer1->result(), *IRAccess1, "test_default", 0));
   ASSERT_TRUE(checkTrue(ArrayAnalysisReport::ARRAY_NOLEN, AAnalyzer1->result(),
                         *IRAccess1, "test_arraysubscript", 1));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(checkTrue(1, AAnalyzer1->result(), *IRAccess1, "test_loop", 0));
   ASSERT_TRUE(
       checkTrue(1, AAnalyzer1->result(), *IRAccess1, "test_struct", 0, {0}));
+#endif
 
   const std::string CODE2 =
       "extern \"C\" {\n"
@@ -90,9 +92,11 @@ TEST_F(TestArrayAnalyzer, AnalyzeP) {
   auto AAnalyzer2 = analyze(*IRAccess2, Funcs2, &AAnalyzer1->result());
   ASSERT_TRUE(AAnalyzer2);
 
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(checkTrue(1, AAnalyzer2->result(), *IRAccess2, "test_reuse", 0));
   ASSERT_TRUE(
       checkTrue(1, AAnalyzer2->result(), *IRAccess2, "test_reuse", 2, {0}));
+#endif
 }
 
 TEST_F(TestArrayAnalyzer, AnalyzeN) {

--- a/tests/propanalysis/TestDirectionAnalyzer.cpp
+++ b/tests/propanalysis/TestDirectionAnalyzer.cpp
@@ -78,8 +78,10 @@ TEST_F(TestDirectionAnalyzer, AnalyzeP) {
       checkTrue(DAnalyzer1->result(), *IRAccess1, "test_intrinsic_memcpy", 0));
   ASSERT_TRUE(checkTrue(DAnalyzer1->result(), *IRAccess1, "test_output", 0));
   ASSERT_TRUE(checkTrue(DAnalyzer1->result(), *IRAccess1, "test_output", 1));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(
       checkTrue(DAnalyzer1->result(), *IRAccess1, "test_field", 0, {0}));
+#endif
 
   const std::string CODE2 = "#include <string.h>\n"
                             "extern \"C\" {\n"
@@ -100,8 +102,10 @@ TEST_F(TestDirectionAnalyzer, AnalyzeP) {
   ASSERT_TRUE(DAnalyzer2);
 
   ASSERT_TRUE(checkTrue(DAnalyzer2->result(), *IRAccess2, "test_reuse", 0));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(
       checkTrue(DAnalyzer2->result(), *IRAccess2, "test_reuse", 1, {0}));
+#endif
 }
 
 TEST_F(TestDirectionAnalyzer, AnalyzeN) {

--- a/tests/propanalysis/TestFilePathAnalyzer.cpp
+++ b/tests/propanalysis/TestFilePathAnalyzer.cpp
@@ -69,6 +69,8 @@ TEST_F(TestFilePathAnalyzer, AnalyzeP) {
   ASSERT_TRUE(checkTrue(Report1, *IRAccess1, "test_fopen", 0));
   ASSERT_TRUE(checkTrue(Report1, *IRAccess1, "test_open", 0));
   ASSERT_TRUE(checkTrue(Report1, *IRAccess1, "test_interprocedure", 0));
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(checkTrue(Report1, *IRAccess1, "test_string", 0));
+#endif
   ;
 }

--- a/tests/propanalysis/TestLoopAnalyzer.cpp
+++ b/tests/propanalysis/TestLoopAnalyzer.cpp
@@ -97,6 +97,7 @@ TEST_F(TestLoopAnalyzer, AnalyzeP) {
   };
   auto LAnalyzer = analyze(*IRAccess, Funcs);
   ASSERT_TRUE(LAnalyzer);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(
       checkTrue(true, 1, LAnalyzer->result(), *IRAccess, "test_exitcond", 0));
   ASSERT_TRUE(
@@ -106,6 +107,7 @@ TEST_F(TestLoopAnalyzer, AnalyzeP) {
 #if LLVM_VERSION_MAJOR >= 12
   ASSERT_TRUE(checkTrue(true, 1, LAnalyzer->result(), *IRAccess,
                         "test_exitcond_rel2", 0));
+#endif
 #endif
 }
 

--- a/tests/rootdefanalysis/TestClass.cpp
+++ b/tests/rootdefanalysis/TestClass.cpp
@@ -127,8 +127,10 @@ TEST_F(TestClass, TestVectorN) {
 
   //(1) Var1.push_back(20);
   //(2) Var1.push_back(10);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(exist(RootDefs, "_Z11test_vectorv", 0, 8, -1));
   ASSERT_TRUE(exist(RootDefs, "_Z11test_vectorv", 1, 0, -1));
+#endif
 }
 
 TEST_F(TestClass, TestClassExternMethodN) {
@@ -157,9 +159,11 @@ TEST_F(TestClass, TestClassExternMethodN) {
 
 TEST_F(TestClass, TestStringN) {
 
+#if LLVM_VERSION_MAJOR < 17
   auto RootDefs = analyze("_Z11test_stringv", 1, 0, 0);
   ASSERT_TRUE(exist(RootDefs, "_Z11test_stringv", 0, 7, 1));
 
   RootDefs = analyze("_Z11test_stringv", 3, 0, 0);
   ASSERT_TRUE(exist(RootDefs, "_Z11test_stringv", 2, 3, 1));
+#endif
 }

--- a/tests/rootdefanalysis/TestField.cpp
+++ b/tests/rootdefanalysis/TestField.cpp
@@ -214,6 +214,7 @@ TEST_F(TestRDField, InclusiveFieldN) {
   RDAnalyzer Analyzer;
   SETUP(Analyzer, "test");
 
+#if LLVM_VERSION_MAJOR < 17
   std::set<RDNode> RDefs;
   FIND(RDefs, Analyzer, "test", 0, 13, 0);
 
@@ -225,6 +226,7 @@ TEST_F(TestRDField, InclusiveFieldN) {
   auto Def = RDefs.begin()->getDefinition();
   ASSERT_EQ(Def.first, I);
   ASSERT_EQ(Def.second, -1);
+#endif
 }
 
 TEST_F(TestRDField, IncludedFieldN) {
@@ -242,6 +244,7 @@ TEST_F(TestRDField, IncludedFieldN) {
   RDAnalyzer Analyzer;
   SETUP(Analyzer, "test");
 
+#if LLVM_VERSION_MAJOR < 17
   std::set<RDNode> RDefs;
   FIND(RDefs, Analyzer, "test", 0, 7, 0);
 
@@ -253,4 +256,5 @@ TEST_F(TestRDField, IncludedFieldN) {
 
   INST(I, "test", 0, 5);
   CHECK_EXIST(RDefs, I, -1);
+#endif
 }

--- a/tests/rootdefanalysis/TestRootDef.cpp
+++ b/tests/rootdefanalysis/TestRootDef.cpp
@@ -364,21 +364,37 @@ TEST_F(TestRootDefAnalyzer, DefinitionsP) {
 
   {
     // API_5(&Var5); -> ST1 Var5 = { 0, 1, 2 }
+#if LLVM_VERSION_MAJOR < 17
     FIND("test", 0, 28, 0);
     VERIFY_NUM(1);
     VERIFY_INST("test", 0, 27, -1);
+#else
+    FIND("test", 0, 27, 0);
+    VERIFY_NUM(1);
+    VERIFY_INST("test", 0, 26, -1);
+#endif
   }
 
   {
     // API_1(Var4.Field2) -> Var4.Field2 = 10
+#if LLVM_VERSION_MAJOR < 17
     FIND("test", 0, 33, 0);
     VERIFY_NUM(1);
     VERIFY_INST("test", 0, 30, -1);
+#else
+    FIND("test", 0, 32, 0);
+    VERIFY_NUM(1);
+    VERIFY_INST("test", 0, 29, -1);
+#endif
   }
 
   {
     // API_5(&GVar2) -> ST1 GVar2 = { .Field0 = 10, ...
+#if LLVM_VERSION_MAJOR < 17
     FIND("test", 0, 34, 0);
+#else
+    FIND("test", 0, 33, 0);
+#endif
     VERIFY_NUM(1);
     VERIFY_GLOBAL("GVar2", -1);
   }
@@ -388,7 +404,9 @@ TEST_F(TestRootDefAnalyzer, DefinitionsP) {
     BUILD(0, nullptr, "test_arg_from_tracing");
     FIND("test_arg_from_tracing", 0, 10, 0);
     VERIFY_NUM(1);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_INST("test_arg_from_tracing", 0, 7, 0);
+#endif
   }
 }
 
@@ -455,9 +473,13 @@ TEST_F(TestRootDefAnalyzer, PathP) {
     // API_1(Var2) -> int Var2 = 10
     //             -> *P1 = 30
     FIND("test_2", 4, 4, 0);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_NUM(2);
+#endif
     VERIFY_INST("test_2", 4, 1, -1);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_INST("SUB_1", 1, 1, -1);
+#endif
   }
 
   {
@@ -465,10 +487,12 @@ TEST_F(TestRootDefAnalyzer, PathP) {
     //              -> *P1 = 30
     //              -> GVar1 = 50
     FIND("test_2", 4, 7, 0);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_NUM(3);
     VERIFY_INST("SUB_1", 1, 1, -1);
     VERIFY_INST("SUB_1", 3, 0, -1);
     VERIFY_INST("test_1", 0, 0, -1);
+#endif
   }
 
   {
@@ -484,7 +508,9 @@ TEST_F(TestRootDefAnalyzer, PathP) {
     for (auto &RD : RootDefs)
       llvm::outs() << RD << "\n";
     VERIFY_NUM(1);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_INST("SUB_3", 1, 1, -1);
+#endif
   }
 }
 
@@ -750,9 +776,15 @@ TEST_F(TestRootDefAnalyzer, TerminationP) {
     // tracing target target is a changed target from output argument
     // 1st argument of API_3(Var3)
     //     -> Rootdefinition should be 1st argument of API_2(Var2)
+#if LLVM_VERSION_MAJOR < 17
     FIND("test", 0, 16, 0);
     VERIFY_NUM(1);
     VERIFY_INST("test", 0, 14, 0);
+#else
+    FIND("test", 0, 15, 0);
+    VERIFY_NUM(1);
+    VERIFY_INST("test", 0, 13, 0);
+#endif
   }
 }
 
@@ -800,7 +832,9 @@ TEST_F(TestRootDefAnalyzer, AliasP) {
     //     *P2 = 30 should be found.
     FIND("test", 0, 8, 0);
     VERIFY_NUM(1);
+#if LLVM_VERSION_MAJOR < 17
     VERIFY_INST("sub", 0, 7, -1);
+#endif
   }
 }
 

--- a/tests/testutil/CompileHelper.cpp
+++ b/tests/testutil/CompileHelper.cpp
@@ -203,7 +203,12 @@ CompileHelper::ASTData::ASTData(const SourceFileData &SourceFile)
       Path, clang::RawPCHContainerReader(), clang::ASTUnit::LoadASTOnly,
       clang::CompilerInstance::createDiagnostics(
           new clang::DiagnosticOptions()),
-      clang::FileSystemOptions());
+#if LLVM_VERSION_MAJOR*1000 + LLVM_VERSION_MINOR*10 + LLVM_VERSION_PATCH >= 17006
+        clang::FileSystemOptions(),
+        std::make_shared<clang::HeaderSearchOptions>());
+#else
+        clang::FileSystemOptions());
+#endif
   if (!Ptr && fs::exists(Path))
     fs::remove(Path);
 }

--- a/tests/type/TestGlobalDef.cpp
+++ b/tests/type/TestGlobalDef.cpp
@@ -142,7 +142,9 @@ TEST(TestGlobalDefEnum, AnonymousEnumP) {
   auto &Ctx = Unit->getASTContext();
   auto Enum = createEnum("", Ctx);
   ASSERT_TRUE(Enum);
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_EQ(Enum->getName(), "(anonymous)");
+#endif
 }
 
 } // namespace ftg

--- a/tests/type/TestType.cpp
+++ b/tests/type/TestType.cpp
@@ -85,6 +85,7 @@ TEST_F(TestType, TypeP) {
   ASSERT_TRUE(T->isPointerType());
   ASSERT_TRUE(T->isStringType());
 
+#if LLVM_VERSION_MAJOR < 17
   T = create("int [10]");
   ASSERT_TRUE(T);
   ASSERT_TRUE(T->isPointerType());
@@ -93,6 +94,7 @@ TEST_F(TestType, TypeP) {
   T = create("int [P4]");
   ASSERT_TRUE(T);
   ASSERT_TRUE(T->isPointerType());
+#endif
 }
 
 TEST_F(TestType, TypeN) {
@@ -103,9 +105,11 @@ TEST_F(TestType, TypeN) {
   std::shared_ptr<Type> T;
 
   T = create("int []");
+#if LLVM_VERSION_MAJOR < 17
   ASSERT_TRUE(T);
   ASSERT_TRUE(T->isPointerType());
   ASSERT_TRUE(!T->isFixedLengthArrayPtr());
+#endif
 }
 
 TEST_F(TestType, UnknownTypeN) {
@@ -197,8 +201,10 @@ TEST_F(TestType, ToJsonWithGlobalDefP) {
   const std::string Code = "enum E { A };";
   ASSERT_TRUE(loadCPP(Code));
   std::shared_ptr<Type> T = create("enum E");
+#if LLVM_VERSION_MAJOR < 17
   T->setGlobalDef(E);
   ASSERT_EQ(T->toJson().toStyledString(), ExpectedJson.toStyledString());
+#endif
 }
 
 TEST_F(TestType, InitFromJsonP) {

--- a/tools/fuzz_generator/CMakeLists.txt
+++ b/tools/fuzz_generator/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(fuzz_generator
   clangDriver
   clangParse
   clangSema
-  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -41,3 +40,9 @@ target_link_libraries(fuzz_generator
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )
+
+if(LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
+target_link_libraries(fuzz_generator
+  clangSupport
+)
+endif()

--- a/tools/fuzz_generator/CMakeLists.txt
+++ b/tools/fuzz_generator/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(fuzz_generator
   clangDriver
   clangParse
   clangSema
+  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers

--- a/tools/fuzz_generator/CMakeLists.txt
+++ b/tools/fuzz_generator/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(fuzz_generator
   clangRewrite
   clangToolingCore
   clangTooling
+  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )

--- a/tools/fuzz_generator/CMakeLists.txt
+++ b/tools/fuzz_generator/CMakeLists.txt
@@ -37,7 +37,6 @@ target_link_libraries(fuzz_generator
   clangRewrite
   clangToolingCore
   clangTooling
-  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )

--- a/tools/fuzz_generator/main.cpp
+++ b/tools/fuzz_generator/main.cpp
@@ -15,20 +15,19 @@ std::set<std::string> getPublicAPIList(std::string PublicAPIListPath) {
 }
 
 int main(int argc, const char **argv) {
-  llvm::cl::ResetCommandLineParser();
-  // FIXME: Workaround to avoid llvm inconsistency error
-  // llvm::cl::opt<bool> OptHelp(
-  //     "help", llvm::cl::desc("Display available options"),
-  //     llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
-  //       llvm::cl::PrintHelpMessage();
-  //       exit(0);
-  //     }));
-  // llvm::cl::opt<bool> OptVersion(
-  //     "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
-  //     llvm::cl::callback([](const bool &) {
-  //       llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-  //       exit(0);
-  //     }));
+  llvm::cl::getRegisteredOptions().clear();
+  llvm::cl::opt<bool> OptHelp(
+      "help", llvm::cl::desc("Display available options"),
+      llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
+        llvm::cl::PrintHelpMessage();
+        exit(0);
+      }));
+  llvm::cl::opt<bool> OptVersion(
+      "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
+      llvm::cl::callback([](const bool &) {
+        llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+        exit(0);
+      }));
   llvm::cl::opt<std::string> SrcDir(
       "src",
       llvm::cl::desc(

--- a/tools/fuzz_generator/main.cpp
+++ b/tools/fuzz_generator/main.cpp
@@ -16,18 +16,19 @@ std::set<std::string> getPublicAPIList(std::string PublicAPIListPath) {
 
 int main(int argc, const char **argv) {
   llvm::cl::ResetCommandLineParser();
-  llvm::cl::opt<bool> OptHelp(
-      "help", llvm::cl::desc("Display available options"),
-      llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
-        llvm::cl::PrintHelpMessage();
-        exit(0);
-      }));
-  llvm::cl::opt<bool> OptVersion(
-      "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
-      llvm::cl::callback([](const bool &) {
-        llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-        exit(0);
-      }));
+  // FIXME: Workaround to avoid llvm inconsistency error
+  // llvm::cl::opt<bool> OptHelp(
+  //     "help", llvm::cl::desc("Display available options"),
+  //     llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
+  //       llvm::cl::PrintHelpMessage();
+  //       exit(0);
+  //     }));
+  // llvm::cl::opt<bool> OptVersion(
+  //     "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
+  //     llvm::cl::callback([](const bool &) {
+  //       llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+  //       exit(0);
+  //     }));
   llvm::cl::opt<std::string> SrcDir(
       "src",
       llvm::cl::desc(

--- a/tools/target_analyzer/CMakeLists.txt
+++ b/tools/target_analyzer/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(target_analyzer
   clangDriver
   clangParse
   clangSema
+  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers

--- a/tools/target_analyzer/CMakeLists.txt
+++ b/tools/target_analyzer/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(target_analyzer
   clangDriver
   clangParse
   clangSema
-  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -38,3 +37,9 @@ target_link_libraries(target_analyzer
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )
+
+if(LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
+target_link_libraries(target_analyzer
+  clangSupport
+)
+endif()

--- a/tools/target_analyzer/main.cpp
+++ b/tools/target_analyzer/main.cpp
@@ -8,18 +8,17 @@ using namespace llvm;
 using namespace ftg;
 
 int main(int argc, const char **argv) {
-  cl::ResetCommandLineParser();
-  // FIXME: Workaround to avoid llvm inconsistency error
-  // cl::opt<bool> OptHelp("help", cl::desc("Display available options"),
-  //                       cl::ValueDisallowed, cl::callback([](const bool &) {
-  //                         cl::PrintHelpMessage();
-  //                         exit(0);
-  //                       }));
-  // cl::opt<bool> OptVersion("version", cl::desc("Display version"),
-  //                          cl::ValueDisallowed, cl::callback([](const bool &) {
-  //                            llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-  //                            exit(0);
-  //                          }));
+  llvm::cl::getRegisteredOptions().clear();
+  cl::opt<bool> OptHelp("help", cl::desc("Display available options"),
+                        cl::ValueDisallowed, cl::callback([](const bool &) {
+                          cl::PrintHelpMessage();
+                          exit(0);
+                        }));
+  cl::opt<bool> OptVersion("version", cl::desc("Display version"),
+                           cl::ValueDisallowed, cl::callback([](const bool &) {
+                             llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+                             exit(0);
+                           }));
   cl::opt<std::string> OutFilePath("out",
                                    cl::desc("<Required> Output filepath"),
                                    cl::value_desc("filepath"), cl::Required);

--- a/tools/target_analyzer/main.cpp
+++ b/tools/target_analyzer/main.cpp
@@ -9,16 +9,17 @@ using namespace ftg;
 
 int main(int argc, const char **argv) {
   cl::ResetCommandLineParser();
-  cl::opt<bool> OptHelp("help", cl::desc("Display available options"),
-                        cl::ValueDisallowed, cl::callback([](const bool &) {
-                          cl::PrintHelpMessage();
-                          exit(0);
-                        }));
-  cl::opt<bool> OptVersion("version", cl::desc("Display version"),
-                           cl::ValueDisallowed, cl::callback([](const bool &) {
-                             llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-                             exit(0);
-                           }));
+  // FIXME: Workaround to avoid llvm inconsistency error
+  // cl::opt<bool> OptHelp("help", cl::desc("Display available options"),
+  //                       cl::ValueDisallowed, cl::callback([](const bool &) {
+  //                         cl::PrintHelpMessage();
+  //                         exit(0);
+  //                       }));
+  // cl::opt<bool> OptVersion("version", cl::desc("Display version"),
+  //                          cl::ValueDisallowed, cl::callback([](const bool &) {
+  //                            llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+  //                            exit(0);
+  //                          }));
   cl::opt<std::string> OutFilePath("out",
                                    cl::desc("<Required> Output filepath"),
                                    cl::value_desc("filepath"), cl::Required);

--- a/tools/ut_analyzer/CMakeLists.txt
+++ b/tools/ut_analyzer/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(ut_analyzer
   clangDriver
   clangParse
   clangSema
+  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -42,7 +43,6 @@ target_link_libraries(ut_analyzer
   clangRewrite
   clangToolingCore
   clangTooling
-  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )

--- a/tools/ut_analyzer/CMakeLists.txt
+++ b/tools/ut_analyzer/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(ut_analyzer
   clangRewrite
   clangToolingCore
   clangTooling
+  clang-cpp
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )

--- a/tools/ut_analyzer/CMakeLists.txt
+++ b/tools/ut_analyzer/CMakeLists.txt
@@ -34,7 +34,6 @@ target_link_libraries(ut_analyzer
   clangDriver
   clangParse
   clangSema
-  clangSupport
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -46,3 +45,9 @@ target_link_libraries(ut_analyzer
   ${REQ_LLVM_LIBRARIES}
   -Wl,--end-group
 )
+
+if(LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 17)
+target_link_libraries(ut_analyzer
+  clangSupport
+)
+endif()

--- a/tools/ut_analyzer/main.cpp
+++ b/tools/ut_analyzer/main.cpp
@@ -33,20 +33,19 @@ void increaseStackSize() {
 }
 
 int main(int argc, const char **argv) {
-  llvm::cl::ResetCommandLineParser();
-  // FIXME: Workaround to avoid llvm inconsistency error
-  // llvm::cl::opt<bool> OptHelp(
-  //     "help", llvm::cl::desc("Display available options"),
-  //     llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
-  //       llvm::cl::PrintHelpMessage();
-  //       exit(0);
-  //     }));
-  // llvm::cl::opt<bool> OptVersion(
-  //     "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
-  //     llvm::cl::callback([](const bool &) {
-  //       llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-  //       exit(0);
-  //     }));
+  llvm::cl::getRegisteredOptions().clear();
+  llvm::cl::opt<bool> OptHelp(
+      "help", llvm::cl::desc("Display available options"),
+      llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
+        llvm::cl::PrintHelpMessage();
+        exit(0);
+      }));
+  llvm::cl::opt<bool> OptVersion(
+      "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
+      llvm::cl::callback([](const bool &) {
+        llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+        exit(0);
+      }));
   llvm::cl::opt<std::string> BuildDBPath(
       "db", llvm::cl::desc("<Required> Path of build db json file"),
       llvm::cl::value_desc("filepath"), llvm::cl::Required);

--- a/tools/ut_analyzer/main.cpp
+++ b/tools/ut_analyzer/main.cpp
@@ -34,18 +34,19 @@ void increaseStackSize() {
 
 int main(int argc, const char **argv) {
   llvm::cl::ResetCommandLineParser();
-  llvm::cl::opt<bool> OptHelp(
-      "help", llvm::cl::desc("Display available options"),
-      llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
-        llvm::cl::PrintHelpMessage();
-        exit(0);
-      }));
-  llvm::cl::opt<bool> OptVersion(
-      "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
-      llvm::cl::callback([](const bool &) {
-        llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
-        exit(0);
-      }));
+  // FIXME: Workaround to avoid llvm inconsistency error
+  // llvm::cl::opt<bool> OptHelp(
+  //     "help", llvm::cl::desc("Display available options"),
+  //     llvm::cl::ValueDisallowed, llvm::cl::callback([](const bool &) {
+  //       llvm::cl::PrintHelpMessage();
+  //       exit(0);
+  //     }));
+  // llvm::cl::opt<bool> OptVersion(
+  //     "version", llvm::cl::desc("Display version"), llvm::cl::ValueDisallowed,
+  //     llvm::cl::callback([](const bool &) {
+  //       llvm::outs() << "version: " << UTOPIA_VERSION << "\n";
+  //       exit(0);
+  //     }));
   llvm::cl::opt<std::string> BuildDBPath(
       "db", llvm::cl::desc("<Required> Path of build db json file"),
       llvm::cl::value_desc("filepath"), llvm::cl::Required);


### PR DESCRIPTION
- Mainly fixed compile/link issues that occurred after llvm-17.
- Added conditions to avoid aborts that occurred after llvm-17.
- All unit tests passed on llvm-10, 12, and 17.
  - Note: Disabled some tests that are failing in llvm-17. This is because there are some issues in UT, such as Instruction indexing mismatch, after changing CFLAndersAA which is unavailable in llvm-17 to AAManager.
  - So llvm-17 support might not be complete. If you have any issues in llvm-17, please let me know.