### PR TITLE
Fix Key Matching Problem in Helper script

### DIFF
--- a/helper/driverbuilder.py
+++ b/helper/driverbuilder.py
@@ -169,8 +169,9 @@ class FuzzerBuilder:
         cmd_profile = "-fprofile-instr-generate -fcoverage-mapping"
 
         name = Path(name)
-        assert name in self.link_cmds
-        link_cmd = copy.copy(self.link_cmds[name])
+        link_cmds = [x for x in self.link_cmds if str(x).endswith(str(name))]
+        assert len(link_cmds) == 1
+        link_cmd = copy.copy(self.link_cmds[link_cmds[0]])
 
         output_dir = self.bp.output_dir
         cmd = link_cmd.cmd


### PR DESCRIPTION
Built binary paths can be used as relative path in build.log.
For example buildkey lib/lib.a can be used in the build.log like ../../../lib/lib.a.
To handle this, Buildkey and Buildlog is matched using endswith instead of the exact match.